### PR TITLE
fix development documentation url errors for networkdao mainnet testnet

### DIFF
--- a/src/app/network-dao/_src/config/config.js
+++ b/src/app/network-dao/_src/config/config.js
@@ -30,7 +30,7 @@ const BUILD_ENDPOINT =
   process.argv[process.argv.indexOf("--CHAIN_ENDPOINT") + 1];
 // const MAINCHAINID = "AELF";
 // MAIN TESTNET
-const NETWORK_TYPE = "TESTNET";
+const NETWORK_TYPE = networkType === 'TESTNET' ? "TESTNET" : "MAIN";
 // ChainId: AELF
 // ChainId: tDVV(AElf public chain)
 const CHAINS_LINK = {


### PR DESCRIPTION
navigate to different development documentation links based on the environment, close #185 