### PR TITLE
network-dao tab overflow not working in ios

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -147,6 +147,7 @@ input[type='number'] {
 .TMRWDAO-pagination-container .TMRWDAO-select-selector {
   @apply !border-Neutral-Disable-Text;
 }
+.antExplorer-tabs-nav,
 .TMRWDAO-tabs-nav {
   overflow: hidden!important;
 }


### PR DESCRIPTION
network-dao tab overflow content, close #231 