### PR TITLE
comment body word break

### DIFF
--- a/src/app/proposal/[proposalId]/components/Discussion/index.css
+++ b/src/app/proposal/[proposalId]/components/Discussion/index.css
@@ -22,7 +22,7 @@
     }
   }
   .body {
-    @apply normal-text mt-[16px];
+    @apply normal-text mt-[16px] break-words;
   }
   .message-lists {
     @apply mb-[24px];


### PR DESCRIPTION
use overflow-wrap: break-word to break comment content. #343 