### PR TITLE
clear vote item percent margin top

### DIFF
--- a/src/app/telegram/votigram/components/VoteItem/index.css
+++ b/src/app/telegram/votigram/components/VoteItem/index.css
@@ -4,7 +4,7 @@
   border: 1px solid var(--Border-1, #403493);
   .vote-item-percent {
     z-index: 1;
-    @apply  h-full w-0 opacity-25 bg-[#ACA6FF] absolute left-0 top-[1px];
+    @apply  h-full w-0 opacity-25 bg-[#ACA6FF] absolute left-0 top-[0px];
   }
 }
 .telegram-vote-item-wrap {


### PR DESCRIPTION
The percentage of the voting width for each item removes the top margin. #467 