### PR TITLE
refer page use votigramActivityVote field from response

### DIFF
--- a/src/api/typing/telegram.d.ts
+++ b/src/api/typing/telegram.d.ts
@@ -191,6 +191,7 @@ interface IRewardInfo {
   estimatedReward: number;
   accountCreation: number;
   votigramVote: number;
+  votigramActivityVote: number;
 }
 interface IGetInviteDetailResponse {
   code: number;

--- a/src/app/telegram/votigram/components/Referral/index.tsx
+++ b/src/app/telegram/votigram/components/Referral/index.tsx
@@ -209,7 +209,7 @@ export default function Referral(props: IReferralProps) {
               <img src="/images/tg/vote-icon.png" alt="" />
               <span className="font-14-18">Votigram Vote</span>
             </div>
-            {BigNumber(inviteDetailRes?.data?.votigramVote ?? 0).toFormat()}
+            {BigNumber(inviteDetailRes?.data?.votigramActivityVote ?? 0).toFormat()}
           </div>
         </div>
       </div>


### PR DESCRIPTION
The invitation page uses the votigramActivityVote field. #547 