### PR TITLE
 add alias params to comment api

### DIFF
--- a/src/api/typing/telegram.d.ts
+++ b/src/api/typing/telegram.d.ts
@@ -286,9 +286,7 @@ interface IDiscoverAppItem {
 // ------------------- discover view -------------------
 interface IGetDiscoverAppViewRes {
   code: string;
-  data: {
-    discoverViewd: boolean;
-  };
+  data: boolean;
 }
 
 // ------------------- confirm choose -------------------

--- a/src/app/telegram/votigram/pageComponents/Discover/DiscoverItem/index.css
+++ b/src/app/telegram/votigram/pageComponents/Discover/DiscoverItem/index.css
@@ -21,7 +21,7 @@
     }
   }
   .cover-image {
-    @apply w-full h-[200px] my-[16px] rounded-2xl;
+    @apply w-full h-[200px] mt-[16px] rounded-2xl;
     object-fit: cover;
     object-position: center;
   }
@@ -30,7 +30,14 @@
     font-size: 14px;
     font-weight: 400;
     line-height: 20px;
+    margin-top: 16px;
     margin-bottom: 24px;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    color: var(--hint_color);
+    display: -webkit-box;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   .tag-wrap {
     @apply flex overflow-scroll;
@@ -45,7 +52,7 @@
   border-top: 1px solid var(--Black-BG-Hover-D, #1b1b1b);
 }
 .discover-app-detail-drawer {
-  max-height: 100vh;
+  height: 100vh;
   overflow-y: scroll;
   background: #000;
   .drawer-body {

--- a/src/app/telegram/votigram/pageComponents/Discover/DiscoverItem/index.tsx
+++ b/src/app/telegram/votigram/pageComponents/Discover/DiscoverItem/index.tsx
@@ -41,7 +41,12 @@ export default function DiscoverItem(props: IDiscoverProps) {
           </a>
         </div>
         {item.screenshots?.[0] && <img src={item.screenshots[0]} alt="" className="cover-image" />}
-        <p className="description">{item.description}</p>
+        <p
+          className="description"
+          dangerouslySetInnerHTML={{
+            __html: item.longDescription,
+          }}
+        ></p>
       </div>
       <CommonDrawer
         title="app details"

--- a/src/app/telegram/votigram/pageComponents/Discover/Discussion/index.tsx
+++ b/src/app/telegram/votigram/pageComponents/Discover/Discussion/index.tsx
@@ -64,8 +64,7 @@ export default function Discussion(props: IDiscussionProps) {
     const reqParams: ICommentListsReq = {
       maxResultCount: 10,
       chainId: curChain,
-      // alias: alias,
-      proposalId: 'fbd29bd94db5490d3631ea88bf6ceac61db1397a5100a92512849b4b8159055b',
+      alias: alias,
     };
     if (lastComment) {
       reqParams.skipId = lastComment.id;
@@ -109,16 +108,14 @@ export default function Discussion(props: IDiscussionProps) {
     // add to db
     const latestCommentRes = await addCommentReq({
       chainId: curChain,
-      // alias: alias,
-      proposalId: 'fbd29bd94db5490d3631ea88bf6ceac61db1397a5100a92512849b4b8159055b',
+      alias: alias,
       comment: content,
       parentId: parentId,
     });
     const reqParams: ICommentListsReq = {
       maxResultCount: 1,
       chainId: curChain,
-      // alias: alias,
-      proposalId: 'fbd29bd94db5490d3631ea88bf6ceac61db1397a5100a92512849b4b8159055b',
+      alias: alias,
     };
     const res = await getCommentLists(reqParams);
     if (res.data.totalCount) {

--- a/src/app/telegram/votigram/pageComponents/Discover/InfiniteList.tsx
+++ b/src/app/telegram/votigram/pageComponents/Discover/InfiniteList.tsx
@@ -7,6 +7,7 @@ import useInfiniteScrollUI from 'react-infinite-scroll-hook';
 import Loading from '../../components/Loading';
 import DiscoverItem from './DiscoverItem';
 import { RefreshIcon } from 'components/Icons';
+import { ETelegramAppCategory } from '../../type';
 
 interface InfiniteListProps {
   category: string;
@@ -32,7 +33,7 @@ export default function InfiniteList(props: InfiniteListProps) {
     const len = currentList.length + preList.length;
     return {
       list: currentList,
-      hasData: len < res.data?.totalCount,
+      hasData: category === ETelegramAppCategory.Recommend ? true : len < res.data?.totalCount,
     };
   };
   const {
@@ -59,7 +60,6 @@ export default function InfiniteList(props: InfiniteListProps) {
     listReload();
   }, []);
   const isLoading = listLoading || listLoadingMore;
-  console.log('listData', listData?.list.length, listLoading, listLoadingMore);
   return (
     <div>
       {listLoading
@@ -81,9 +81,7 @@ export default function InfiniteList(props: InfiniteListProps) {
         className="text-white flex-center discover-app-list-refresh-icon"
         onClick={() => {
           document.body.scrollTop = 0;
-          setTimeout(() => {
-            listReload();
-          }, 300);
+          listReload();
         }}
       >
         <RefreshIcon />

--- a/src/app/telegram/votigram/pageComponents/Discover/index.tsx
+++ b/src/app/telegram/votigram/pageComponents/Discover/index.tsx
@@ -86,11 +86,15 @@ export default function Discover() {
   const chooseDrawerRef = useRef<ICommonDrawerRef>(null);
   const wrapRef = useRef<HTMLDivElement>(null);
   const [selectedCategory, setSelectedCategory] = useState<string[]>([]);
-  const handleConfirmLike = () => {
-    discoverConfirmChoose({
-      chainId: curChain,
-      choices: selectedCategory,
-    });
+  const handleConfirmLike = async () => {
+    try {
+      await discoverConfirmChoose({
+        chainId: curChain,
+        choices: selectedCategory,
+      });
+    } finally {
+      chooseDrawerRef.current?.close();
+    }
   };
   const onSelectChange = (checkedValues: string[]) => {
     setSelectedCategory(checkedValues);
@@ -99,10 +103,9 @@ export default function Discover() {
     const viewRes = await getDiscoverAppView({
       chainId: curChain,
     });
-    if (!viewRes.data.discoverViewd) {
+    if (!viewRes.data) {
       chooseDrawerRef.current?.open();
     }
-    chooseDrawerRef.current?.open();
   }, []);
   const handleTabClick: (activeKey: string, e: any) => void = (key, event) => {
     // const min = 0;


### PR DESCRIPTION
When calling the comment API, use alias instead of proposalid. #568 